### PR TITLE
Set isDragged to false before calling stopDrag's callbacks

### DIFF
--- a/lib/src/drag_source.dart
+++ b/lib/src/drag_source.dart
@@ -133,6 +133,7 @@ class DragSource {
 
   void stopDrag() {
     if (isDragging) {
+      isDragging = false;
       _onDragEndController.add(_dragEvent);
       _globalOnDragEndController.add(_dragEvent);
       _cleanupDrag();
@@ -164,7 +165,6 @@ class DragSource {
     _dragImage._hide();
     _dragImage = null;
     _dragEvent = null;
-    isDragging = false;
   }
 
   void _setupListenersForLogging() {


### PR DESCRIPTION
@danschultz PTAL

It's weird that when we execute the callbacks in stopDrag, we still have
isDragged = true.
