### PR TITLE
Fix bug when mouseMove calls after mouseUp in DragManager

### DIFF
--- a/lib/src/drag_manager.dart
+++ b/lib/src/drag_manager.dart
@@ -4,7 +4,6 @@ DragManager _dragManager = new DragManager();
 
 class DragManager {
   StreamSubscription _mouseMove;
-  StreamSubscription _mouseUp;
 
   List<DropTarget> _targets = [];
   DropTarget _activeTarget;
@@ -12,24 +11,19 @@ class DragManager {
   DragManager() {
     globalOnDragStart.listen((event) {
       _mouseMove = window.onMouseMove.listen(_onMouseMove);
-      _mouseUp = window.onMouseUp.listen(_onMouseUp);
     });
 
     globalOnDragEnd.listen((_) {
       _mouseMove.cancel();
-      _mouseUp.cancel();
+      if (_activeTarget != null) {
+        _activeTarget._drop();
+        _activeTarget = null;
+      }
     });
   }
 
   void _onMouseMove(MouseEvent event) {
     _checkTargets(_dragImage._elementUnder(event.client));
-  }
-
-  void _onMouseUp(MouseEvent event) {
-    if (_activeTarget != null) {
-      _activeTarget._drop();
-      _activeTarget = null;
-    }
   }
 
   void _checkTargets(Element element) {


### PR DESCRIPTION
@danschultz PTAL

This should never happen (because we may reset _activeTarget back after
setting it to null in _mouseUp, which can cause exceptions).

But sometimes that may happen (e.g. in Chrome on Windows), because we
actually call globalOnDragEnd on the next tick after mouseUp. So,
sometimes the sequence of calls may be:

```
mouseMove -> mouseUp -> mouseMove -> globalOnDragEnd
```

To avoid that problem, let's just clear up _activeTarget in
globalOnDragEnd
