### PR TITLE
Don't accept drops if the target is disabled

### DIFF
--- a/lib/src/drag_manager.dart
+++ b/lib/src/drag_manager.dart
@@ -27,7 +27,7 @@ class DragManager {
   void _onMouseUp(MouseEvent event) {
     _mouseMove.cancel();
 
-    if (_activeTarget != null) {
+    if (_activeTarget != null && !_activeTarget.isDropCancelled) {
       _activeTarget._drop();
       _activeTarget = null;
       _activeSource.stopDrag(true);

--- a/lib/src/drag_manager.dart
+++ b/lib/src/drag_manager.dart
@@ -27,7 +27,7 @@ class DragManager {
   void _onMouseUp(MouseEvent event) {
     _mouseMove.cancel();
 
-    if (_activeTarget != null && !_activeTarget.isDropCancelled) {
+    if (_activeTarget != null && _activeTarget.isEnabled) {
       _activeTarget._drop();
       _activeTarget = null;
       _activeSource.stopDrag(true);

--- a/lib/src/drag_source.dart
+++ b/lib/src/drag_source.dart
@@ -14,7 +14,7 @@ class DragSource {
   final Element element;
 
   int distance = 5;
-  bool enabled = true;
+  bool isEnabled = true;
   DragImageFactory feedbackImage;
   final DragData data = new DragData();
 
@@ -121,7 +121,7 @@ class DragSource {
     element.classes.remove(IS_GRABBING);
     element.classes.add(IS_DRAGGING);
 
-    if (!isDragging && enabled) {
+    if (!isDragging && isEnabled) {
       if (manual) {
         if (pointerPosition != null) {
           _lastPointerPosition = pointerPosition;

--- a/lib/src/drop_target.dart
+++ b/lib/src/drop_target.dart
@@ -17,6 +17,8 @@ class DropTarget {
   bool _isAccepted = false;
   bool get isAccepted => _isAccepted;
 
+  bool isDropCancelled = false;
+
   StreamSubscription _mouseMove;
   StreamSubscription _mouseUp;
 

--- a/lib/src/drop_target.dart
+++ b/lib/src/drop_target.dart
@@ -6,7 +6,7 @@ typedef void DropHandler(Object data);
 class DropTarget {
   final Element element;
 
-  bool enabled = true;
+  bool isEnabled = true;
 
   var _handlers = {};
   Map<String, DropHandler> get handlers => _handlers;
@@ -16,8 +16,6 @@ class DropTarget {
 
   bool _isAccepted = false;
   bool get isAccepted => _isAccepted;
-
-  bool isDropCancelled = false;
 
   StreamSubscription _mouseMove;
   StreamSubscription _mouseUp;
@@ -53,25 +51,25 @@ class DropTarget {
   }
 
   void _enter() {
-    if (enabled) {
+    if (isEnabled) {
       _onDragEnterController.add(_dragEvent);
     }
   }
 
   void _leave() {
-    if (enabled) {
+    if (isEnabled) {
       _onDragLeaveController.add(_dragEvent);
     }
   }
 
   void _hover() {
-    if (enabled) {
+    if (isEnabled) {
       _onDragOverController.add(_dragEvent);
     }
   }
 
   void _drop() {
-    if (enabled) {
+    if (isEnabled) {
       _onDropController.add(_dragEvent);
     }
   }


### PR DESCRIPTION
You can set this flag when you don't want cancel action even if user
drops to the target.